### PR TITLE
Disable blob download in backup script

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -9,7 +9,6 @@ ACCOUNT="${1#@}"
 
 rm -f "$ACCOUNT".car
 goat repo export -o "$ACCOUNT".car "$ACCOUNT"
-goat blob export "$ACCOUNT"
 goat resolve "$ACCOUNT" > "$ACCOUNT".json
 goat plc data "$ACCOUNT" > "$ACCOUNT"_plc.json
 goat plc history "$ACCOUNT" > "$ACCOUNT"_plc_history.jsonc


### PR DESCRIPTION
I have removed the `goat blob export` command from the backup script to prevent it from downloading blobs.

This was done at your request, as you handle blob backups separately and want to avoid storing them in the git repository, which can cause the repository to become very large.

As per your confirmation, the generation of metadata files (.json, .jsonc) is preserved.